### PR TITLE
Fix memory leaks in Flutter forms

### DIFF
--- a/scs_dashboard/lib/screens/devices/device_form_screen.dart
+++ b/scs_dashboard/lib/screens/devices/device_form_screen.dart
@@ -49,6 +49,13 @@ class _DeviceFormScreenState extends State<DeviceFormScreen> {
   }
 
   @override
+  void dispose() {
+    _deviceIdCtrl.dispose();
+    _typeCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isNew = widget.device == null;
     return Scaffold(

--- a/scs_dashboard/lib/screens/login_screen.dart
+++ b/scs_dashboard/lib/screens/login_screen.dart
@@ -85,6 +85,14 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
+  @override
+  void dispose() {
+    _serverCtrl.dispose();
+    _usernameCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
   void _submit() async {
     if (!_formKey.currentState!.validate()) return;
     setState(() {

--- a/scs_dashboard/lib/screens/rules/rule_form_screen.dart
+++ b/scs_dashboard/lib/screens/rules/rule_form_screen.dart
@@ -82,6 +82,16 @@ class _RuleFormScreenState extends State<RuleFormScreen> {
   }
 
   @override
+  void dispose() {
+    _deviceIdCtrl.dispose();
+    _pinIdCtrl.dispose();
+    _conditionCtrl.dispose();
+    _actionCtrl.dispose();
+    _scheduleCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isNew = widget.rule == null;
     return Scaffold(

--- a/scs_dashboard/lib/screens/users/user_form_screen.dart
+++ b/scs_dashboard/lib/screens/users/user_form_screen.dart
@@ -54,6 +54,13 @@ class _UserFormScreenState extends State<UserFormScreen> {
   }
 
   @override
+  void dispose() {
+    _usernameCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isNew = widget.user == null;
     return Scaffold(


### PR DESCRIPTION
## Summary
- dispose controllers in LoginScreen
- dispose controllers in DeviceFormScreen
- dispose controllers in UserFormScreen
- dispose controllers in RuleFormScreen

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687416699e4c832e95c676e8e6591b66