### PR TITLE
Add admin view with status and firmware upload

### DIFF
--- a/Roadmap.txt
+++ b/Roadmap.txt
@@ -35,7 +35,7 @@ Phase 5 - Monitoring, Logging und Alarmierung
 2. Echtzeit-Log-Viewer im Dashboard. (erledigt)
 3. Benachrichtigungssystem (E-Mail, WebPush, Telegram/WhatsApp) fuer Alarme (erledigt)
    sowie Push-Mitteilungen in der Control-App.
-4. Server-Administrationsansicht mit Systemstatus und Firmware-Upload.
+4. Server-Administrationsansicht mit Systemstatus und Firmware-Upload. (erledigt)
 5. Tägliche Datenbank-Backups und JSON-Exporte.
 
 

--- a/scs-server/package-lock.json
+++ b/scs-server/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mqtt": "^5.13.1",
+        "multer": "^1.4.5-lts.1",
         "mysql2": "^3.14.1",
         "node-cron": "^4.1.0",
         "nodemailer": "^6.9.11",
@@ -396,6 +397,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -602,6 +609,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -814,6 +832,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1740,6 +1764,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2129,6 +2159,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -2239,6 +2281,113 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/multer/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/multer/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mysql2": {
       "version": "3.14.1",
@@ -3230,6 +3379,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3693,6 +3850,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/scs-server/package.json
+++ b/scs-server/package.json
@@ -18,6 +18,7 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mqtt": "^5.13.1",
+    "multer": "^1.4.5-lts.1",
     "mysql2": "^3.14.1",
     "node-cron": "^4.1.0",
     "nodemailer": "^6.9.11",

--- a/scs-server/src/controllers/adminController.js
+++ b/scs-server/src/controllers/adminController.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+exports.getStatus = (req, res) => {
+  try {
+    return res.json({
+      uptime: process.uptime(),
+      memory: process.memoryUsage().rss,
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Fehler beim Abrufen des Status.' });
+  }
+};
+
+exports.uploadFirmware = (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: 'Keine Datei hochgeladen.' });
+    }
+    const destDir = path.join(__dirname, '../../uploads');
+    if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+    const target = path.join(destDir, req.file.originalname);
+    fs.renameSync(req.file.path, target);
+    return res.status(201).json({ message: 'Firmware hochgeladen.' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Upload fehlgeschlagen.' });
+  }
+};

--- a/scs-server/src/index.js
+++ b/scs-server/src/index.js
@@ -60,6 +60,10 @@ const io = socketIo(server, {
   const ruleRoutes = require('./routes/rule');
   app.use('/api/v1/rules', ruleRoutes);
 
+// Admin-Management
+  const adminRoutes = require('./routes/admin');
+  app.use('/api/v1/admin', adminRoutes);
+
 // 4. Datenbankverbindung initialisieren
 const sequelize = new Sequelize(
   process.env.DB_NAME, 

--- a/scs-server/src/routes/admin.js
+++ b/scs-server/src/routes/admin.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const { authenticate, authorize } = require('../utils/authMiddleware');
+const adminController = require('../controllers/adminController');
+const multer = require('multer');
+
+const upload = multer({ dest: 'tmp/' });
+
+router.get('/status', authenticate, authorize(['admin']), adminController.getStatus);
+router.post('/firmware', authenticate, authorize(['admin']), upload.single('firmware'), adminController.uploadFirmware);
+
+module.exports = router;

--- a/scs_dashboard/lib/screens/admin/admin_screen.dart
+++ b/scs_dashboard/lib/screens/admin/admin_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import '../../services/admin_service.dart';
+
+class AdminScreen extends StatefulWidget {
+  final String ip;
+  const AdminScreen({Key? key, required this.ip}) : super(key: key);
+
+  @override
+  _AdminScreenState createState() => _AdminScreenState();
+}
+
+class _AdminScreenState extends State<AdminScreen> {
+  late AdminService _service;
+  Map<String, dynamic>? _status;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final baseUrl = 'http://${widget.ip}:3000/api/v1';
+    _service = AdminService(baseUrl);
+    _load();
+  }
+
+  Future<void> _load() async {
+    final s = await _service.fetchStatus();
+    setState(() {
+      _status = s;
+      _loading = false;
+    });
+  }
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles();
+    if (result != null) {
+      final path = result.files.single.path;
+      if (path != null) {
+        await _service.uploadFirmware(path);
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Firmware hochgeladen')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Administration')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Uptime: ${_status?['uptime']}'),
+                  Text('Memory: ${_status?['memory']}'),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: _pickFile,
+                    child: const Text('Firmware hochladen'),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/scs_dashboard/lib/screens/dashboard_screen.dart
+++ b/scs_dashboard/lib/screens/dashboard_screen.dart
@@ -11,6 +11,7 @@ import 'devices/device_list_screen.dart';
 import '../models/device.dart';
 import 'package:provider/provider.dart';
 import '../../theme_manager.dart';
+import 'admin/admin_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
   final String ip;
@@ -139,6 +140,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
               context,
               MaterialPageRoute(
                 builder: (_) => UserListScreen(ip: widget.ip),
+              ),
+            ),
+          ),
+
+          // Administration
+          IconButton(
+            icon: const Icon(Icons.admin_panel_settings),
+            tooltip: 'Administration',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => AdminScreen(ip: widget.ip),
               ),
             ),
           ),

--- a/scs_dashboard/lib/services/admin_service.dart
+++ b/scs_dashboard/lib/services/admin_service.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class AdminService {
+  final Dio _dio;
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  AdminService(String baseUrl) : _dio = Dio(BaseOptions(baseUrl: baseUrl));
+
+  Future<Map<String, dynamic>> fetchStatus() async {
+    final token = await _storage.read(key: 'jwt');
+    final resp = await _dio.get(
+      '/admin/status',
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
+    );
+    return Map<String, dynamic>.from(resp.data as Map);
+  }
+
+  Future<void> uploadFirmware(String path) async {
+    final token = await _storage.read(key: 'jwt');
+    final formData = FormData.fromMap({
+      'firmware': await MultipartFile.fromFile(path),
+    });
+    await _dio.post(
+      '/admin/firmware',
+      data: formData,
+      options: Options(headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'multipart/form-data',
+      }),
+    );
+  }
+}

--- a/scs_dashboard/pubspec.lock
+++ b/scs_dashboard/pubspec.lock
@@ -373,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "f52c772316bed112fb0a225e0eaa90bf34e66b4fab79e2b0690f9bfb0c5b7b20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
   socket_io_common:
     dependency: transitive
     description:

--- a/scs_dashboard/pubspec.yaml
+++ b/scs_dashboard/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   flutter_secure_storage: ^9.2.4
   intl: 0.17.0
   socket_io_client: ^3.1.2
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement admin controller and routes for system status and firmware upload
- expose admin endpoints in Express app
- add AdminService and AdminScreen in Flutter dashboard
- link to new admin UI from dashboard
- enable file selection with file_picker dependency
- mark roadmap entry for admin view done

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688642ada144832ea75b85102020f31f